### PR TITLE
WIP: Cache data when remote db can't be reached

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -202,16 +202,25 @@ def format_payload(data):
         payload += f" value={value_m} {epoch}\n"  
     return payload
 
-
-def main():
-    global uuid, command
-    uuid = get_uuid()
+def select_os(args):
     if args.mac_os:
         command = "../scrap/MACOS/scrap.sh"
     elif args.linux:
         command = "../scrap/Linux/scrap.sh"
     else:
         raise AssertionError("OS not specified")
+    return command #inutile car command est global
+
+def select_logging_mode(args):
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+def main():
+    global uuid, command
+    uuid = get_uuid() #inutile car uuid est global
+    command = select_os(args) #inutile car uuid est global
     while True:
         send_cached_payloads()
         client()
@@ -220,16 +229,15 @@ def main():
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    if args.debug:
-        logging.basicConfig(level=logging.DEBUG)
+    select_logging_mode(args)
+    dir_path = os.path.dirname(os.path.realpath(__file__)) ## Get the directory path of the file
+    error_logs_file = open(dir_path+'/../logs/error_logs.txt','a')
+    debug_logs_file = open(dir_path+'/../logs/debug_logs.txt','a')
+    context = daemon.DaemonContext(
+        working_directory = dir_path,
+        stderr = error_logs_file,
+        stdout = debug_logs_file
+    )
+    with context:
+        print("Debug logs file init.")
         main()
-    else:
-        logging.basicConfig(level=logging.INFO)
-        dir_path = os.path.dirname(os.path.realpath(__file__)) ## Get the directory path of the file
-        error_logs_file = open(dir_path+'/../logs/error_logs.txt','a')
-        context = daemon.DaemonContext(
-            working_directory = dir_path,
-            stderr = error_logs_file
-        )
-        with context:
-            main()


### PR DESCRIPTION
## Comportement étrange
Marche très bien quand il n'est pas exécuté en tant que daemon. Comportement étrange sinon.

## Modif mineur
Quand l'argument `--debug` est actif, le client ne se lance pas en mode daemon

## Cache
   * Quand la DB n'est plus accessible, les payloads sont gardées en cache dans le fichier `~/.battery_probe/queue`
   * Une fois que la DB est à nouveau accessible, on itère sur tout le contenu pour envoyer les payloads qui sont restées en mémoire
      * Si la DB est à nouveau inaccessible alors qu'on est entrain de vider ce cache (très peu probable, mais c'est un code de production donc il faut que ce soit fiable à 100%), on remet ce qui n'a pas été envoyé en cache.

**IMPORTANT:**
Dans les cas où la DB est inaccessible pendant un long moment, le fichier où est stocké le cache risque de devenir trop volumineux. J'ai mis WIP parce qu'il faudrait modifer la fonction `cache_payload` pour vérifier d'abord que le fichier n'est pas trop volumineux avant d'ajouter une autre payload.
Si c'est le cas, il faudrait sélectionner quelles payloads garder (plus récente d'abord ? plus ancienne d'abord ? sélection plus intelligente ?).
